### PR TITLE
Fix section completion: make self-managed completion an explicit flag

### DIFF
--- a/components/form-templates/form-accordion-item.tsx
+++ b/components/form-templates/form-accordion-item.tsx
@@ -393,8 +393,14 @@ export default function FormAccordionItem({
   // Check if section has any status fields and get their completion state
   // Use section.fields to react to updates from custom layouts
   const statusFieldsState = useMemo(() => {
+    // Only sections that explicitly opt in manage their own completion.
+    // This must be a declared section property — never inferred from field
+    // names, or real fields like `org_legal_status` / `npo_status` would be
+    // mistaken for status markers and lock the section as "Incomplete".
+    if (!section?.selfManagedCompletion) return null;
+
     const fields = section?.fields || fieldsWithDefaults;
-    // Find all fields that end with _status and check their values
+    // Within an opted-in section, the hidden `*_status` field stores the value.
     const statusFields = fields.filter((f: Field) => f.name.endsWith('_status'));
     if (statusFields.length === 0) return null;
     
@@ -407,7 +413,7 @@ export default function FormAccordionItem({
       isComplete: !hasIncomplete && hasComplete,
       isIncomplete: hasIncomplete
     };
-  }, [section?.fields, fieldsWithDefaults]);
+  }, [section?.selfManagedCompletion, section?.fields, fieldsWithDefaults]);
 
   // Use ref to track previous state to prevent unnecessary updates
   const prevSectionRef = useRef<{

--- a/docs/FORM_TEMPLATES.md
+++ b/docs/FORM_TEMPLATES.md
@@ -62,6 +62,7 @@ Form templates are JSON files that define the structure, fields, and behavior of
 | `description` | string | No | Explanatory text below title |
 | `notice` | string | No | Highlighted notice box |
 | `editable_by` | string[] | No | Roles that can edit (empty = locked) |
+| `selfManagedCompletion` | boolean | No | Section shows **Complete/Incomplete** (driven by a custom layout's hidden `*_status` field) instead of the default "x/x Required" count. See [form-template-reference.md](form-template-reference.md#section-completion-display) |
 | `fields` | Field[] | Yes | Array of field definitions |
 
 ---

--- a/docs/form-template-reference.md
+++ b/docs/form-template-reference.md
@@ -35,6 +35,26 @@ This document describes all available field types, layouts, modifiers, and secti
 | `editable_by` | `string[]` | Restrict editing to specific roles. If omitted, editable by anyone |
 | `visible_to` | `string[]` | Restrict visibility to specific roles. If omitted, visible to everyone |
 | `admin_feedback` | `boolean` | Enables admin feedback UI on this section |
+| `selfManagedCompletion` | `boolean` | Opt this section out of the default required-field count. Its header shows **Complete / Incomplete** instead of "x/x Required", driven by a hidden `*_status` field written by a custom layout. See below. |
+
+### Section completion display
+
+By default a section header shows a required-field count (`3/3 Required`) and the section is considered complete when every `required` field is valid.
+
+Some custom layouts (`casework-categories`, `finalised-cases`, `garden-beneficiaries`, `garden-yields`) can't express completeness as a simple field count. They instead compute it themselves and write `"complete"` / `"incomplete"` into a hidden helper field named in their `config.statusField`. For that to drive the header, the **section must opt in explicitly** with `"selfManagedCompletion": true`.
+
+```json
+{
+  "title": "New cases",
+  "selfManagedCompletion": true,
+  "fields": [
+    { "name": "new_cases", "type": "group", "layout": "casework-categories", "config": { "statusField": "new_cases_status", "...": "..." }, "fields": [] },
+    { "name": "new_cases_status", "type": "text", "label": "", "show": false }
+  ]
+}
+```
+
+> **Important:** completion is opt-in per section and is **never** inferred from field names. The `_status` suffix carries no special meaning on its own — a normal field such as `org_legal_status` or `npo_status` is treated as an ordinary field and does **not** switch the section into self-managed mode. Only sections with `"selfManagedCompletion": true` read the hidden status field.
 
 ---
 
@@ -502,7 +522,7 @@ Category-based data grid with configurable columns. Used with `type: "group"`.
 }
 ```
 
-**Requires a hidden status field:**
+**Requires a hidden status field, and the containing section must set `"selfManagedCompletion": true`** (see [Section completion display](#section-completion-display)):
 ```json
 { "name": "new_cases_status", "type": "text", "label": "", "show": false }
 ```
@@ -541,6 +561,8 @@ Extended version of casework-categories with demographics breakdown (gender, rac
 }
 ```
 
+Requires a hidden `finalised_cases_status` field, and the containing section must set `"selfManagedCompletion": true` (see [Section completion display](#section-completion-display)).
+
 ### `garden-beneficiaries`
 
 Garden-linked layout for tracking employees and beneficiaries with demographics. References a `sourceField` repeatable.
@@ -568,6 +590,8 @@ Garden-linked layout for tracking employees and beneficiaries with demographics.
 }
 ```
 
+Requires a hidden `garden_beneficiaries_status` field, and the containing section must set `"selfManagedCompletion": true` (see [Section completion display](#section-completion-display)).
+
 ### `garden-yields`
 
 Garden-linked layout for tracking farmed items with configurable columns. References a `sourceField` repeatable.
@@ -591,6 +615,8 @@ Garden-linked layout for tracking farmed items with configurable columns. Refere
   "fields": []
 }
 ```
+
+Requires a hidden `garden_yields_status` field, and the containing section must set `"selfManagedCompletion": true` (see [Section completion display](#section-completion-display)).
 
 ### `data-grid`
 

--- a/form-templates/narrative-report.json
+++ b/form-templates/narrative-report.json
@@ -269,6 +269,7 @@
     {
       "tag": "Casework",
       "title": "New cases",
+      "selfManagedCompletion": true,
       "show_if": { "field": "casework_enabled", "value": "true" },
       "fields": [
         {
@@ -369,6 +370,7 @@
     {
       "tag": "Casework",
       "title": "Finalised cases",
+      "selfManagedCompletion": true,
       "show_if": { "field": "casework_enabled", "value": "true" },
       "fields": [
         {
@@ -628,6 +630,7 @@
     {
       "tag": "Food gardening",
       "title": "Community garden beneficiaries",
+      "selfManagedCompletion": true,
       "show_if": { "field": "food_gardening_enabled", "value": "true" },
       "fields": [
         {
@@ -703,6 +706,7 @@
     {
       "title": "Community garden yields",
       "tag": "Food gardening",
+      "selfManagedCompletion": true,
       "show_if": { "field": "food_gardening_enabled", "value": "true" },
       "fields": [
         {

--- a/types/forms.ts
+++ b/types/forms.ts
@@ -61,6 +61,10 @@ export interface Section {
   visible_to?: string[];
   admin_feedback?: boolean;
   show_if?: { field: string; value: string };
+  // When true, the section manages its own completion via a hidden `*_status`
+  // field written by a custom layout, instead of the default "x/x required"
+  // count. Must be set explicitly — do NOT infer it from field names.
+  selfManagedCompletion?: boolean;
 }
 
 export type FormData = Record<string, string | number | boolean | null | undefined>


### PR DESCRIPTION
Section completion was inferred from any field whose name ended in `_status`, which collided with real fields (e.g. `org_legal_status`, `npo_status`) and locked those sections as "Incomplete" forever.

Gate the status-field detection on an explicit `selfManagedCompletion` section property instead of the name suffix. The hidden `*_status` field still stores the value written by custom layouts; only opted-in sections read it. Opt in the 4 narrative-report sections that rely on it, and document the flag in the form-template references.