### PR TITLE
Add Reporting tab to dashboard with indicator keyword search

### DIFF
--- a/app/api/dashboard/stats/route.ts
+++ b/app/api/dashboard/stats/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
 import { getServerSession } from "next-auth"
+import { Prisma } from "@prisma/client"
 import { NEXT_AUTH_OPTIONS } from "@/lib/auth"
 import { prisma } from "@/db"
 import { permissions } from "@/lib/permissions"
+import { REPORTING_INDICATORS } from "@/lib/reporting/indicators"
 
 interface DashboardFilters {
   periodStart?: string
@@ -11,6 +13,7 @@ interface DashboardFilters {
   developmentStageIds?: number[]
   focusAreaIds?: number[]
   fundType?: string
+  formStatusIds?: number[]
 }
 
 // A funder/LDA's location is the province code stored on its organisation detail
@@ -56,21 +59,24 @@ export async function GET(req: NextRequest) {
     developmentStageIds: searchParams.get("developmentStageIds")?.split(",").map(Number).filter(Boolean) || undefined,
     focusAreaIds: searchParams.get("focusAreaIds")?.split(",").map(Number).filter(Boolean) || undefined,
     fundType: searchParams.get("fundType") || undefined,
+    formStatusIds: searchParams.get("formStatusIds")?.split(",").map(Number).filter(Boolean) || undefined,
   }
 
   try {
     // Provinces drive both the location filter options and the per-province
     // chart buckets (all provinces are shown, in their stored order).
-    const [provinces, developmentStages, focusAreas] = await Promise.all([
+    const [provinces, developmentStages, focusAreas, formStatuses] = await Promise.all([
       prisma.province.findMany({ orderBy: { id: "asc" } }),
       prisma.developmentStage.findMany({ orderBy: { label: "asc" } }),
       prisma.focusArea.findMany({ orderBy: { label: "asc" } }),
+      prisma.formStatus.findMany({ orderBy: { id: "asc" } }),
     ])
 
-    const [ldaStats, funderStats, fundStats] = await Promise.all([
+    const [ldaStats, funderStats, fundStats, reportingStats] = await Promise.all([
       getLDAStats(filters, provinces),
       getFunderStats(filters, provinces),
       getFundStats(filters),
+      getReportingStats(filters),
     ])
 
     const filterOptions = {
@@ -81,12 +87,14 @@ export async function GET(req: NextRequest) {
         { value: "CORE_FUND", label: "Core" },
         { value: "PROJECT_FUND", label: "Project" },
       ],
+      formStatuses: formStatuses.map(s => ({ id: s.id, label: s.label })),
     }
 
     return NextResponse.json({
       lda: ldaStats,
       funder: funderStats,
       fund: fundStats,
+      reporting: reportingStats,
       filterOptions,
     })
   } catch (error) {
@@ -332,4 +340,96 @@ async function getFundStats(filters: DashboardFilters) {
     totalScatFunded,
     surplus,
   }
+}
+
+// Reporting tab: for each hardcoded indicator, count how often its phrases appear
+// across ALL report answers (drafts included) and how many distinct reports
+// contain them, plus the matching reports so the UI can link to each source.
+//
+// Search runs live against LocalDevelopmentAgencyForm.formData cast to text; the
+// `formData_trgm_idx` GIN trigram index accelerates the ILIKE match. Occurrences
+// are counted case-insensitively via the classic length/replace trick.
+async function getReportingStats(filters: DashboardFilters) {
+  // The LDA-level filters (province, stage, focus area) constrain WHICH reports
+  // are searched, by their owning LDA. Only resolve them when at least one is
+  // active, and reuse Prisma's relation handling rather than raw join-table SQL.
+  let allowedLdaIds: number[] | null = null
+  const ldaFilterActive =
+    !!filters.provinceCodes?.length ||
+    !!filters.developmentStageIds?.length ||
+    !!filters.focusAreaIds?.length
+
+  if (ldaFilterActive) {
+    const ldaWhere: Record<string, unknown> = {}
+    if (filters.provinceCodes?.length) {
+      ldaWhere.organisationDetail = { physicalProvince: { in: filters.provinceCodes } }
+    }
+    if (filters.developmentStageIds?.length) {
+      ldaWhere.developmentStageId = { in: filters.developmentStageIds }
+    }
+    if (filters.focusAreaIds?.length) {
+      ldaWhere.focusAreas = { some: { id: { in: filters.focusAreaIds } } }
+    }
+    const ldas = await prisma.localDevelopmentAgency.findMany({ where: ldaWhere, select: { id: true } })
+    allowedLdaIds = ldas.map(l => l.id)
+    if (allowedLdaIds.length === 0) {
+      // No LDA matches the filters → every indicator is zero.
+      return REPORTING_INDICATORS.map(ind => ({
+        key: ind.key,
+        label: ind.label,
+        occurrences: 0,
+        reportCount: 0,
+        reports: [] as { id: number; ldaId: number; title: string; ldaName: string; count: number }[],
+      }))
+    }
+  }
+
+  // Row-level filters applied to every indicator query (fundType is fund-level
+  // and doesn't apply to reports, matching how the LDAs tab ignores it).
+  const rowFilters: Prisma.Sql[] = []
+  if (allowedLdaIds) rowFilters.push(Prisma.sql`f."localDevelopmentAgencyId" = ANY(${allowedLdaIds})`)
+  if (filters.formStatusIds?.length) rowFilters.push(Prisma.sql`f."formStatusId" = ANY(${filters.formStatusIds})`)
+  if (filters.periodStart) rowFilters.push(Prisma.sql`f."fundingEnd" >= ${new Date(filters.periodStart)}`)
+  if (filters.periodEnd) rowFilters.push(Prisma.sql`f."fundingStart" <= ${new Date(filters.periodEnd)}`)
+
+  const results = []
+  for (const ind of REPORTING_INDICATORS) {
+    // Match when any variant appears (ILIKE OR-chain → trigram index, case-insensitive).
+    const matchOr = Prisma.join(
+      ind.phrases.map(p => Prisma.sql`f."formData"::text ILIKE ${"%" + p + "%"}`),
+      " OR ",
+    )
+    // Per-report occurrence count = sum over variants of (case-insensitive) hits.
+    const occurrenceExpr = Prisma.join(
+      ind.phrases.map(
+        p => Prisma.sql`(char_length(lower(f."formData"::text)) - char_length(replace(lower(f."formData"::text), ${p}, ''))) / char_length(${p})`,
+      ),
+      " + ",
+    )
+    const where = Prisma.join([Prisma.sql`(${matchOr})`, ...rowFilters], " AND ")
+
+    const rows = await prisma.$queryRaw<{ id: number; ldaId: number; title: string; ldaName: string; count: bigint }[]>(Prisma.sql`
+      SELECT f.id, f."localDevelopmentAgencyId" AS "ldaId", f.title, lda.name AS "ldaName", (${occurrenceExpr})::bigint AS count
+      FROM "LocalDevelopmentAgencyForm" f
+      JOIN "LocalDevelopmentAgency" lda ON lda.id = f."localDevelopmentAgencyId"
+      WHERE ${where}
+      ORDER BY count DESC, f."updatedAt" DESC
+    `)
+
+    results.push({
+      key: ind.key,
+      label: ind.label,
+      occurrences: rows.reduce((sum, r) => sum + Number(r.count), 0),
+      reportCount: rows.length,
+      reports: rows.slice(0, 20).map(r => ({
+        id: r.id,
+        ldaId: r.ldaId,
+        title: r.title,
+        ldaName: r.ldaName,
+        count: Number(r.count),
+      })),
+    })
+  }
+
+  return results
 }

--- a/components/dashboard/dashboard-content.tsx
+++ b/components/dashboard/dashboard-content.tsx
@@ -2,18 +2,21 @@
 
 import { useState, useEffect, useMemo, useCallback, startTransition } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { StatCard } from "./stat-card"
 import { HorizontalBarChart } from "./horizontal-bar-chart"
 import { FilterBar } from "@/components/ui/filter-bar"
 import { FilterOption } from "@/components/ui/filter-button"
+import { Link } from "@/i18n/routing"
 import {
-  Target, 
+  Target,
   MapPin,
   ArrowUpDown,
   TriangleRight,
   Handshake,
   Banknote,
-  HandCoins
+  HandCoins,
+  FileText
 } from "lucide-react"
 
 interface ApiFilterOption {
@@ -28,6 +31,7 @@ interface FilterOptions {
   developmentStages: ApiFilterOption[]
   focusAreas: ApiFilterOption[]
   fundTypes: { value: string; label: string }[]
+  formStatuses: { id: number; label: string }[]
 }
 
 interface LDAStats {
@@ -55,10 +59,27 @@ interface FundStats {
   surplus: number
 }
 
+interface ReportingReport {
+  id: number
+  ldaId: number
+  title: string
+  ldaName: string
+  count: number
+}
+
+interface ReportingIndicatorStat {
+  key: string
+  label: string
+  occurrences: number
+  reportCount: number
+  reports: ReportingReport[]
+}
+
 interface DashboardData {
   lda: LDAStats
   funder: FunderStats
   fund: FundStats
+  reporting: ReportingIndicatorStat[]
   filterOptions: FilterOptions
 }
 
@@ -110,9 +131,10 @@ export function DashboardContent() {
     const developmentStageIds = (activeFilters['stage'] || []).map(o => Number(o.id))
     const focusAreaIds = (activeFilters['focus'] || []).map(o => Number(o.id))
     const fundType = activeFilters['fundType']?.[0]?.id as string | undefined
+    const formStatusIds = (activeFilters['reportStatus'] || []).map(o => Number(o.id))
     const periodId = activeFilters['period']?.[0]?.id as string | undefined
     const { periodStart, periodEnd } = getPeriodRange(periodId)
-    return { provinceCodes, developmentStageIds, focusAreaIds, fundType, periodStart, periodEnd }
+    return { provinceCodes, developmentStageIds, focusAreaIds, fundType, formStatusIds, periodStart, periodEnd }
   }, [activeFilters])
 
   const fetchData = useCallback(async () => {
@@ -123,6 +145,7 @@ export function DashboardContent() {
       if (apiFilters.developmentStageIds.length) params.set("developmentStageIds", apiFilters.developmentStageIds.join(","))
       if (apiFilters.focusAreaIds.length) params.set("focusAreaIds", apiFilters.focusAreaIds.join(","))
       if (apiFilters.fundType) params.set("fundType", apiFilters.fundType)
+      if (apiFilters.formStatusIds.length) params.set("formStatusIds", apiFilters.formStatusIds.join(","))
       if (apiFilters.periodStart) params.set("periodStart", apiFilters.periodStart)
       if (apiFilters.periodEnd) params.set("periodEnd", apiFilters.periodEnd)
 
@@ -159,6 +182,10 @@ export function DashboardContent() {
     () => (data?.filterOptions.fundTypes || []).map(({ value, label }) => ({ id: value, label })),
     [data?.filterOptions.fundTypes]
   )
+  const reportStatusOptions = useMemo<FilterOption[]>(
+    () => (data?.filterOptions.formStatuses || []).map(({ id, label }) => ({ id: String(id), label })),
+    [data?.filterOptions.formStatuses]
+  )
 
   // Period filter options
   const periodOptions = useMemo<FilterOption[]>(() => [
@@ -176,14 +203,19 @@ export function DashboardContent() {
     const location = { type: 'location', label: 'Location', options: locationOptions }
     const fundType = { type: 'fundType', label: 'Funding type', options: fundTypeOptions }
     const focus = { type: 'focus', label: 'Focus area', options: focusOptions }
+    const reportStatus = { type: 'reportStatus', label: 'Report status', options: reportStatusOptions }
 
+    if (activeTab === 'reporting') {
+      // Report indicators are filtered by their owning LDA plus report status.
+      return [period, reportStatus, stage, location, focus]
+    }
     if (activeTab === 'ldas') {
       // Funding type is a fund-level attribute and doesn't apply to LDAs.
       return [period, stage, location, focus]
     }
     // Funders / Funds — to be refined later.
     return [period, stage, location, fundType, focus]
-  }, [activeTab, periodOptions, stageOptions, locationOptions, fundTypeOptions, focusOptions])
+  }, [activeTab, periodOptions, stageOptions, locationOptions, fundTypeOptions, focusOptions, reportStatusOptions])
 
   const handleFilterChange = useCallback((filterType: string, selected: FilterOption[]) => {
     startTransition(() => {
@@ -213,6 +245,7 @@ export function DashboardContent() {
           <TabsTrigger value="ldas" className="data-[state=active]:bg-white">LDAs</TabsTrigger>
           <TabsTrigger value="funders" className="data-[state=active]:bg-white">Funders</TabsTrigger>
           <TabsTrigger value="funds" className="data-[state=active]:bg-white">Funds</TabsTrigger>
+          <TabsTrigger value="reporting" className="data-[state=active]:bg-white">Reporting</TabsTrigger>
         </TabsList>
 
         {/* Filters - using same FilterBar as LDAs page */}
@@ -332,13 +365,74 @@ export function DashboardContent() {
               icon={HandCoins}
               format="currency"
             />
-            <StatCard 
-              title="Total surplus/shortfall" 
-              value={data?.fund.surplus || 0} 
+            <StatCard
+              title="Total surplus/shortfall"
+              value={data?.fund.surplus || 0}
               icon={ArrowUpDown}
               format="currency"
             />
           </div>
+        </TabsContent>
+
+        {/* Reporting Tab — indicator keyword counts across report answers, with
+            links to each source report. No charts by design. */}
+        <TabsContent value="reporting" className="mt-6 space-y-6">
+          <div className="rounded-lg border bg-white">
+            {/* Header row */}
+            <div className="grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b px-4 py-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span>Indicator</span>
+              <span className="w-24 text-right">Occurrences</span>
+              <span className="w-20 text-right">Reports</span>
+            </div>
+
+            <Accordion type="multiple" className="w-full">
+              {(data?.reporting || []).map((indicator) => (
+                <AccordionItem key={indicator.key} value={indicator.key} className="border-b last:border-b-0 px-4">
+                  <AccordionTrigger className="hover:no-underline py-3" disabled={indicator.reportCount === 0}>
+                    <div className="grid w-full grid-cols-[1fr_auto_auto] items-center gap-4 pr-2 text-left">
+                      <span className="text-sm font-medium text-slate-900">{indicator.label}</span>
+                      <span className="w-24 text-right text-lg font-bold tabular-nums">
+                        {indicator.occurrences.toLocaleString("en-ZA")}
+                      </span>
+                      <span className="w-20 text-right text-sm text-muted-foreground tabular-nums">
+                        {indicator.reportCount.toLocaleString("en-ZA")}
+                      </span>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    {indicator.reports.length === 0 ? (
+                      <p className="py-2 text-sm text-muted-foreground">No matching reports yet.</p>
+                    ) : (
+                      <ul className="space-y-1 pb-2">
+                        {indicator.reports.map((report) => (
+                          <li key={report.id}>
+                            <Link
+                              href={`/dashboard/ldas/${report.ldaId}/funding-reports/${report.id}/`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex items-center justify-between gap-3 rounded-md px-2 py-2 text-sm hover:bg-slate-50"
+                            >
+                              <span className="flex min-w-0 items-center gap-2">
+                                <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                <span className="truncate text-slate-900">{report.title}</span>
+                                <span className="truncate text-muted-foreground">· {report.ldaName}</span>
+                              </span>
+                              <span className="shrink-0 text-muted-foreground tabular-nums">
+                                {report.count.toLocaleString("en-ZA")}×
+                              </span>
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Counts reflect exact-phrase matches (and close variants) across all report answers, including drafts.
+          </p>
         </TabsContent>
       </Tabs>
     </div>

--- a/lib/reporting/indicators.ts
+++ b/lib/reporting/indicators.ts
@@ -1,0 +1,75 @@
+// High-level reporting indicators surfaced on the dashboard "Reporting" tab.
+//
+// MVP behaviour: each indicator matches by EXACT phrase (case-insensitive,
+// substring) against the text of a report's answers. `phrases` holds the base
+// phrase plus a few curated variants so obvious rewordings still count.
+//
+// This list is intentionally hardcoded for now. The roadmap is:
+//   - later: replace the fixed list with a free-text search box (the same
+//     trigram index on LocalDevelopmentAgencyForm.formData already supports it);
+//   - later: fuzzy matching via pg_trgm similarity / full-text search.
+//
+// Keep `phrases` lowercase — matching is done case-insensitively via ILIKE, and
+// lowercase keeps the intent obvious. Tune the variants once real report data
+// shows what CBOs actually write.
+
+export interface ReportingIndicator {
+  /** Stable identifier used as the React key and in the API response. */
+  key: string
+  /** Human-readable label shown in the Reporting table. */
+  label: string
+  /**
+   * Any of these substrings appearing in a report's answers counts as a match.
+   * "handled" vs "resolved" variants are kept distinct so the two service-delivery
+   * indicators never double-count the same generic phrase.
+   */
+  phrases: string[]
+}
+
+export const REPORTING_INDICATORS: ReportingIndicator[] = [
+  {
+    key: "accountability_actions_taken",
+    label: "Accountability actions taken",
+    phrases: ["accountability action", "accountability actions taken", "accountability measure"],
+  },
+  {
+    key: "government_departments_engaged",
+    label: "Government departments engaged",
+    phrases: ["government department", "departments engaged", "department engaged", "engaged government"],
+  },
+  {
+    key: "service_delivery_issues_handled",
+    label: "Service delivery issues handled",
+    phrases: ["service delivery issues handled", "service delivery issue handled", "handled service delivery"],
+  },
+  {
+    key: "service_delivery_issues_resolved",
+    label: "Service delivery issues resolved",
+    phrases: ["service delivery issues resolved", "service delivery issue resolved", "resolved service delivery"],
+  },
+  {
+    key: "institutional_practices_changed",
+    label: "Institutional practices changed/improved",
+    phrases: [
+      "institutional practice changed",
+      "institutional practices changed",
+      "institutional practice improved",
+      "institutional practices improved",
+    ],
+  },
+  {
+    key: "advocacy_campaigns_protests",
+    label: "Advocacy campaigns, protests conducted",
+    phrases: ["advocacy campaign", "protest conducted", "protests conducted", "conducted a protest"],
+  },
+  {
+    key: "formal_commitments_secured",
+    label: "Formal commitments secured",
+    phrases: ["formal commitment", "formal commitment secured", "formal commitments secured"],
+  },
+  {
+    key: "significant_community_wins",
+    label: "Significant community wins reported",
+    phrases: ["significant community win", "community wins reported", "community win"],
+  },
+]

--- a/prisma/migrations/20260701090000_add_formdata_trgm_search/migration.sql
+++ b/prisma/migrations/20260701090000_add_formdata_trgm_search/migration.sql
@@ -1,0 +1,11 @@
+-- Enable trigram matching so ILIKE '%phrase%' over report answers can use an index.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Accelerate substring/phrase search across all report answers. The report's
+-- answers live in the `formData` JSONB blob; casting it to text lets a single
+-- GIN trigram index serve every keyword/indicator query on the reporting tab
+-- (and any future free-text search) without scanning rows.
+-- This index is not expressible in schema.prisma, so it is created here directly.
+CREATE INDEX IF NOT EXISTS "LocalDevelopmentAgencyForm_formData_trgm_idx"
+  ON "LocalDevelopmentAgencyForm"
+  USING gin ((("formData")::text) gin_trgm_ops);


### PR DESCRIPTION
New 'Reporting' tab (after Funds) surfaces high-level indicators counted across report answers, linking to each source report.

- pg_trgm GIN trigram index on LocalDevelopmentAgencyForm.formData::text for fast ILIKE phrase search (migration; not expressible in schema.prisma)
- Hardcoded indicators + curated variants in lib/reporting/indicators.ts
- getReportingStats(): live per-indicator occurrences + report count + linked reports, honouring period/province/stage/focus and report-status filters
- Reporting tab UI: accordion table (no charts), report status checkbox filter, links open the funding report in a new tab