### PR TITLE
Add searchable combobox to entity-backed select dropdowns

### DIFF
--- a/components/admin/create-form-panel.tsx
+++ b/components/admin/create-form-panel.tsx
@@ -10,21 +10,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
+import { Combobox } from "@/components/ui/combobox"
 import { Input } from "@/components/ui/input"
-import { ArrowLeft, CalendarIcon, Check, ChevronsUpDown, FilePlus, Loader2 } from "lucide-react"
+import { ArrowLeft, CalendarIcon, FilePlus, Loader2 } from "lucide-react"
 import { format } from "date-fns"
 import { toast } from "sonner"
 import { FormTemplateWithRelations, LocalDevelopmentAgencyListItem } from "@/types/models"
 import { LDA_TERMINOLOGY } from "@/constants/lda"
-import { cn } from "@/lib/utils"
 
 interface CreateFormPanelProps {
   ldas: LocalDevelopmentAgencyListItem[]
@@ -44,11 +36,9 @@ export function CreateFormPanel({ ldas, formTemplates, onBack }: CreateFormPanel
   const [loading, setLoading] = useState(false)
   
   // LDA selection state
-  const [ldaOpen, setLdaOpen] = useState(false)
   const [selectedLDA, setSelectedLDA] = useState<string>("")
-  
+
   // Template selection state
-  const [templateOpen, setTemplateOpen] = useState(false)
   const [selectedTemplate, setSelectedTemplate] = useState<string>("")
   
   // Form fields
@@ -58,7 +48,6 @@ export function CreateFormPanel({ ldas, formTemplates, onBack }: CreateFormPanel
   const [fundingEnd, setFundingEnd] = useState<Date | undefined>(undefined)
 
   // Get selected items for display
-  const selectedLDAData = ldas.find(l => String(l.id) === selectedLDA)
   const selectedTemplateData = formTemplates.find(t => String(t.id) === selectedTemplate)
   const sidebarConfig: SidebarConfig = selectedTemplateData?.sidebarConfig as SidebarConfig || {}
   const isReportType = selectedTemplateData?.templateType === 'REPORT'
@@ -148,98 +137,34 @@ export function CreateFormPanel({ ldas, formTemplates, onBack }: CreateFormPanel
           {/* LDA Selection - Searchable */}
           <div className="space-y-2">
             <Label>{LDA_TERMINOLOGY.shortName}</Label>
-            <Popover open={ldaOpen} onOpenChange={setLdaOpen}>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={ldaOpen}
-                  className="w-full justify-between"
-                >
-                  {selectedLDAData ? selectedLDAData.name : `Select ${LDA_TERMINOLOGY.shortName}...`}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-full p-0" align="start">
-                <Command>
-                  <CommandInput placeholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`} />
-                  <CommandList>
-                    <CommandEmpty>No {LDA_TERMINOLOGY.shortName} found.</CommandEmpty>
-                    <CommandGroup>
-                      {ldas.map((lda) => (
-                        <CommandItem
-                          key={lda.id}
-                          value={lda.name}
-                          onSelect={() => {
-                            setSelectedLDA(String(lda.id))
-                            setLdaOpen(false)
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              selectedLDA === String(lda.id) ? "opacity-100" : "opacity-0"
-                            )}
-                          />
-                          {lda.name}
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
+            <Combobox
+              options={ldas.map((lda) => ({
+                value: String(lda.id),
+                label: lda.name,
+              }))}
+              value={selectedLDA}
+              onChange={setSelectedLDA}
+              placeholder={`Select ${LDA_TERMINOLOGY.shortName}...`}
+              searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+              emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+            />
           </div>
 
           {/* Template Selection - Searchable */}
           <div className="space-y-2">
             <Label>Form Template</Label>
-            <Popover open={templateOpen} onOpenChange={setTemplateOpen}>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  role="combobox"
-                  aria-expanded={templateOpen}
-                  className="w-full justify-between"
-                >
-                  {selectedTemplateData ? selectedTemplateData.name : "Select template..."}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-full p-0" align="start">
-                <Command>
-                  <CommandInput placeholder="Search templates..." />
-                  <CommandList>
-                    <CommandEmpty>No template found.</CommandEmpty>
-                    <CommandGroup>
-                      {formTemplates.map((template) => (
-                        <CommandItem
-                          key={template.id}
-                          value={template.name}
-                          onSelect={() => {
-                            setSelectedTemplate(String(template.id))
-                            setTemplateOpen(false)
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              "mr-2 h-4 w-4",
-                              selectedTemplate === String(template.id) ? "opacity-100" : "opacity-0"
-                            )}
-                          />
-                          <div className="flex flex-col">
-                            <span>{template.name}</span>
-                            {template.description && (
-                              <span className="text-xs text-muted-foreground">{template.description}</span>
-                            )}
-                          </div>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  </CommandList>
-                </Command>
-              </PopoverContent>
-            </Popover>
+            <Combobox
+              options={formTemplates.map((template) => ({
+                value: String(template.id),
+                label: template.name,
+                description: template.description ?? undefined,
+              }))}
+              value={selectedTemplate}
+              onChange={setSelectedTemplate}
+              placeholder="Select template..."
+              searchPlaceholder="Search templates..."
+              emptyText="No template found."
+            />
           </div>
 
           {/* Conditional fields based on template sidebar config */}

--- a/components/admin/report-schedules-panel.tsx
+++ b/components/admin/report-schedules-panel.tsx
@@ -27,20 +27,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
+import { Combobox } from "@/components/ui/combobox"
 import { Calendar } from "@/components/ui/calendar"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { ArrowLeft, Calendar as CalendarIcon, Check, ChevronsUpDown, Edit, Loader2, RefreshCw } from "lucide-react"
+import { ArrowLeft, Calendar as CalendarIcon, Edit, Loader2, RefreshCw } from "lucide-react"
 import { format } from "date-fns"
 import { toast } from "sonner"
-import { cn } from "@/lib/utils"
 import { LocalDevelopmentAgencyListItem } from "@/types/models"
 import { LDA_TERMINOLOGY } from "@/constants/lda"
 
@@ -89,7 +81,6 @@ export function ReportSchedulesPanel({ ldas, onBack }: ReportSchedulesPanelProps
   const [configs, setConfigs] = useState<ReportConfig[]>([])
   const [generatedReports, setGeneratedReports] = useState<GeneratedReport[]>([])
   const [selectedLDA, setSelectedLDA] = useState<string>("all")
-  const [ldaOpen, setLdaOpen] = useState(false)
   const [editingSchedule, setEditingSchedule] = useState<PeriodSchedule | null>(null)
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -98,8 +89,6 @@ export function ReportSchedulesPanel({ ldas, onBack }: ReportSchedulesPanelProps
     dueDate: undefined as Date | undefined,
     note: ""
   })
-
-  const selectedLDAData = ldas.find(l => String(l.id) === selectedLDA)
 
   // Refetch configs after updates
   const refetchConfigs = async () => {
@@ -384,38 +373,21 @@ export function ReportSchedulesPanel({ ldas, onBack }: ReportSchedulesPanelProps
                 {/* LDA Filter */}
                 <div className="flex items-center gap-4">
                   <Label>Filter by {LDA_TERMINOLOGY.shortName}:</Label>
-                  <Popover open={ldaOpen} onOpenChange={setLdaOpen}>
-                    <PopoverTrigger asChild>
-                      <Button variant="outline" role="combobox" className="w-[300px] justify-between">
-                        {selectedLDA === 'all' ? `All ${LDA_TERMINOLOGY.shortNamePlural}` : selectedLDAData?.name || 'Select...'}
-                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-[300px] p-0">
-                      <Command>
-                        <CommandInput placeholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`} />
-                        <CommandList>
-                          <CommandEmpty>No results found.</CommandEmpty>
-                          <CommandGroup>
-                            <CommandItem value="all" onSelect={() => { setSelectedLDA('all'); setLdaOpen(false) }}>
-                              <Check className={cn("mr-2 h-4 w-4", selectedLDA === 'all' ? "opacity-100" : "opacity-0")} />
-                              All {LDA_TERMINOLOGY.shortNamePlural}
-                            </CommandItem>
-                            {ldas.map((lda) => (
-                              <CommandItem
-                                key={lda.id}
-                                value={lda.name}
-                                onSelect={() => { setSelectedLDA(String(lda.id)); setLdaOpen(false) }}
-                              >
-                                <Check className={cn("mr-2 h-4 w-4", selectedLDA === String(lda.id) ? "opacity-100" : "opacity-0")} />
-                                {lda.name}
-                              </CommandItem>
-                            ))}
-                          </CommandGroup>
-                        </CommandList>
-                      </Command>
-                    </PopoverContent>
-                  </Popover>
+                  <Combobox
+                    options={[
+                      { value: 'all', label: `All ${LDA_TERMINOLOGY.shortNamePlural}` },
+                      ...ldas.map((lda) => ({
+                        value: String(lda.id),
+                        label: lda.name,
+                      })),
+                    ]}
+                    value={selectedLDA}
+                    onChange={setSelectedLDA}
+                    placeholder="Select..."
+                    searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                    emptyText="No results found."
+                    className="w-[300px]"
+                  />
                 </div>
 
                 {generatedReports.length === 0 ? (

--- a/components/documents/form.tsx
+++ b/components/documents/form.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -194,23 +195,19 @@ export function FormDialog({ document, lda, ldas, callback }: FormDialogProps) {
                 render={({ field }) => (
                   <FormItem className="flex-1 w-full">
                     <FormLabel>{LDA_TERMINOLOGY.fullName}</FormLabel>
-                    <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {ldas.map((lda) => (
-                          <SelectItem
-                            key={lda.id}
-                            value={lda.id.toString()}
-                          >
-                            {lda.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={ldas.map((lda) => ({
+                          value: lda.id.toString(),
+                          label: lda.name,
+                        }))}
+                        value={field.value?.toString()}
+                        onChange={field.onChange}
+                        placeholder={LDA_TERMINOLOGY.selectPlaceholder}
+                        searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                        emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+                      />
+                    </FormControl>
 
                   </FormItem>
                 )} />)}

--- a/components/form-templates/custom-components/SelectField.tsx
+++ b/components/form-templates/custom-components/SelectField.tsx
@@ -2,6 +2,10 @@
 
 import { Field } from "@/types/forms"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
+
+// Option lists longer than this get a searchable combobox instead of a plain select
+const SEARCHABLE_OPTIONS_THRESHOLD = 10
 
 interface SelectFieldProps {
   field: Field
@@ -10,6 +14,23 @@ interface SelectFieldProps {
 }
 
 export function SelectField({ field, isEditing, onValueChange }: SelectFieldProps) {
+  const options = field.options ?? []
+
+  if (options.length > SEARCHABLE_OPTIONS_THRESHOLD) {
+    return (
+      <Combobox
+        options={options.map((option) => ({
+          value: option.value,
+          label: option.label,
+        }))}
+        value={field.value?.toString() || ""}
+        onChange={(value) => onValueChange && onValueChange(field, value)}
+        placeholder={field?.placeholder || "Select an option"}
+        disabled={!isEditing}
+      />
+    )
+  }
+
   return (
     <Select
       name={field.name}
@@ -21,7 +42,7 @@ export function SelectField({ field, isEditing, onValueChange }: SelectFieldProp
         <SelectValue placeholder={field?.placeholder || "Select an option"} />
       </SelectTrigger>
       <SelectContent>
-        {field.options?.map((option) => (
+        {options.map((option) => (
           <SelectItem
             key={option.value}
             value={option.value}

--- a/components/form-templates/form.tsx
+++ b/components/form-templates/form.tsx
@@ -35,6 +35,7 @@ import { ChevronDownIcon, CopyIcon, PencilIcon, PlusIcon } from "lucide-react"
 import { useState } from "react"
 import { FormTemplate } from "@prisma/client"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { Control } from "react-hook-form"
@@ -301,24 +302,22 @@ export function FormDialog({ formTemplate, allTemplates = [] }: FormDialogProps)
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Linked Form Template</FormLabel>
-                    <Select 
-                      value={field.value?.toString() || 'none'} 
-                      onValueChange={(val) => field.onChange(val === 'none' ? null : parseInt(val))}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select form template" />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="none">None</SelectItem>
-                        {availableTemplatesForLinking.map((t) => (
-                          <SelectItem key={t.id} value={t.id.toString()}>
-                            {t.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={[
+                          { value: 'none', label: 'None' },
+                          ...availableTemplatesForLinking.map((t) => ({
+                            value: t.id.toString(),
+                            label: t.name,
+                          })),
+                        ]}
+                        value={field.value?.toString() || 'none'}
+                        onChange={(val) => field.onChange(val === 'none' ? null : parseInt(val))}
+                        placeholder="Select form template"
+                        searchPlaceholder="Search templates..."
+                        emptyText="No templates found."
+                      />
+                    </FormControl>
                   </FormItem>
                 )}
               />
@@ -468,18 +467,17 @@ function CloneDialog({ allTemplates, open, onOpenChange }: CloneDialogProps) {
         <div className="space-y-4 py-4">
           <div className="space-y-2">
             <Label>Select Template to Clone</Label>
-            <Select value={selectedTemplate} onValueChange={handleTemplateSelect}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select a template" />
-              </SelectTrigger>
-              <SelectContent>
-                {allTemplates.map((t) => (
-                  <SelectItem key={t.id} value={t.id.toString()}>
-                    {t.name} ({t.templateType})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Combobox
+              options={allTemplates.map((t) => ({
+                value: t.id.toString(),
+                label: `${t.name} (${t.templateType})`,
+              }))}
+              value={selectedTemplate}
+              onChange={handleTemplateSelect}
+              placeholder="Select a template"
+              searchPlaceholder="Search templates..."
+              emptyText="No templates found."
+            />
           </div>
 
           {selectedTemplate && (
@@ -679,24 +677,22 @@ function CreateNewTemplateForm({ onClose, allTemplates }: CreateNewTemplateFormP
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Linked Form Template</FormLabel>
-                  <Select 
-                    value={field.value?.toString() || 'none'} 
-                    onValueChange={(val) => field.onChange(val === 'none' ? null : parseInt(val))}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select form template" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">None</SelectItem>
-                      {allTemplates.map((t) => (
-                        <SelectItem key={t.id} value={t.id.toString()}>
-                          {t.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <FormControl>
+                    <Combobox
+                      options={[
+                        { value: 'none', label: 'None' },
+                        ...allTemplates.map((t) => ({
+                          value: t.id.toString(),
+                          label: t.name,
+                        })),
+                      ]}
+                      value={field.value?.toString() || 'none'}
+                      onChange={(val) => field.onChange(val === 'none' ? null : parseInt(val))}
+                      placeholder="Select form template"
+                      searchPlaceholder="Search templates..."
+                      emptyText="No templates found."
+                    />
+                  </FormControl>
                 </FormItem>
               )}
             />

--- a/components/form-templates/report-schedule-config.tsx
+++ b/components/form-templates/report-schedule-config.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { toast } from "sonner"
@@ -426,25 +427,21 @@ export function ReportScheduleConfigDialog({
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label>Report Template</Label>
-                      <Select
+                      <Combobox
+                        options={reportTemplates
+                          .filter((t) => t.templateType === "REPORT")
+                          .map((t) => ({
+                            value: t.id.toString(),
+                            label: t.name,
+                          }))}
                         value={newConfig.reportTemplateId}
-                        onValueChange={(val) =>
+                        onChange={(val) =>
                           setNewConfig({ ...newConfig, reportTemplateId: val })
                         }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select report template" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {reportTemplates
-                            .filter((t) => t.templateType === "REPORT")
-                            .map((t) => (
-                              <SelectItem key={t.id} value={t.id.toString()}>
-                                {t.name}
-                              </SelectItem>
-                            ))}
-                        </SelectContent>
-                      </Select>
+                        placeholder="Select report template"
+                        searchPlaceholder="Search templates..."
+                        emptyText="No templates found."
+                      />
                     </div>
 
                     <div className="space-y-2">

--- a/components/funders/form.tsx
+++ b/components/funders/form.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import { FocusArea, Province, FundStatus } from '@prisma/client'
@@ -506,20 +507,19 @@ export function FormDialog({ funder, focusAreas, provinces, callback }: FormDial
                               name="physicalProvince"
                               render={({ field }) => (
                                 <FormItem>
-                                  <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                                    <FormControl>
-                                      <SelectTrigger>
-                                        <SelectValue placeholder="Select province" />
-                                      </SelectTrigger>
-                                    </FormControl>
-                                    <SelectContent>
-                                      {provinces.map((province) => (
-                                        <SelectItem key={province.code} value={province.code}>
-                                          {province.name}
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
+                                  <FormControl>
+                                    <Combobox
+                                      options={provinces.map((province) => ({
+                                        value: province.code,
+                                        label: province.name,
+                                      }))}
+                                      value={field.value?.toString()}
+                                      onChange={field.onChange}
+                                      placeholder="Select province"
+                                      searchPlaceholder="Search provinces..."
+                                      emptyText="No province found."
+                                    />
+                                  </FormControl>
                                 </FormItem>
                               )}
                             />
@@ -624,20 +624,19 @@ export function FormDialog({ funder, focusAreas, provinces, callback }: FormDial
                                 name="postalProvince"
                                 render={({ field }) => (
                                   <FormItem>
-                                    <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                                      <FormControl>
-                                        <SelectTrigger>
-                                          <SelectValue placeholder="Select province" />
-                                        </SelectTrigger>
-                                      </FormControl>
-                                      <SelectContent>
-                                        {provinces.map((province) => (
-                                          <SelectItem key={province.code} value={province.code}>
-                                            {province.name}
-                                          </SelectItem>
-                                        ))}
-                                      </SelectContent>
-                                    </Select>
+                                    <FormControl>
+                                      <Combobox
+                                        options={provinces.map((province) => ({
+                                          value: province.code,
+                                          label: province.name,
+                                        }))}
+                                        value={field.value?.toString()}
+                                        onChange={field.onChange}
+                                        placeholder="Select province"
+                                        searchPlaceholder="Search provinces..."
+                                        emptyText="No province found."
+                                      />
+                                    </FormControl>
                                   </FormItem>
                                 )}
                               />

--- a/components/funders/link-funder-dialog.tsx
+++ b/components/funders/link-funder-dialog.tsx
@@ -11,13 +11,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Calendar } from "@/components/ui/calendar"
 import {
   Popover,
@@ -244,18 +238,17 @@ export function LinkFunderDialog({ fundId, fundName, funderId, funderName, avail
                     <Lock className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   </div>
                 ) : (
-                  <Select value={selectedFunder} onValueChange={setSelectedFunder}>
-                    <SelectTrigger id="funder">
-                      <SelectValue placeholder="Select a funder" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableFunders?.map((funder) => (
-                        <SelectItem key={funder.id} value={String(funder.id)}>
-                          {funder.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Combobox
+                    options={availableFunders?.map((funder) => ({
+                      value: String(funder.id),
+                      label: funder.name,
+                    })) ?? []}
+                    value={selectedFunder}
+                    onChange={setSelectedFunder}
+                    placeholder="Select a funder"
+                    searchPlaceholder="Search funders..."
+                    emptyText="No funder found."
+                  />
                 )}
               </div>
 
@@ -273,18 +266,17 @@ export function LinkFunderDialog({ fundId, fundName, funderId, funderName, avail
                     <Lock className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   </div>
                 ) : (
-                  <Select value={selectedFund} onValueChange={setSelectedFund}>
-                    <SelectTrigger id="fund">
-                      <SelectValue placeholder="Select a fund" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableFunds?.map((fund) => (
-                        <SelectItem key={fund.id} value={String(fund.id)}>
-                          {fund.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Combobox
+                    options={availableFunds?.map((fund) => ({
+                      value: String(fund.id),
+                      label: fund.name,
+                    })) ?? []}
+                    value={selectedFund}
+                    onChange={setSelectedFund}
+                    placeholder="Select a fund"
+                    searchPlaceholder="Search funds..."
+                    emptyText="No fund found."
+                  />
                 )}
               </div>
 

--- a/components/funds/link-lda-dialog.tsx
+++ b/components/funds/link-lda-dialog.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Calendar } from "@/components/ui/calendar"
 import {
   Popover,
@@ -202,18 +203,18 @@ export function LinkLDADialog({ fundId, fundName, fundDefaultAmount, availableLD
                     <Lock className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                   </div>
                 ) : (
-                  <Select value={selectedLDA} onValueChange={setSelectedLDA}>
-                    <SelectTrigger id="lda">
-                      <SelectValue placeholder={LDA_TERMINOLOGY.selectPlaceholder} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableLDAs.map((lda) => (
-                        <SelectItem key={lda.id} value={String(lda.id)}>
-                          {lda.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Combobox
+                    id="lda"
+                    options={availableLDAs.map((lda) => ({
+                      value: String(lda.id),
+                      label: lda.name,
+                    }))}
+                    value={selectedLDA}
+                    onChange={setSelectedLDA}
+                    placeholder={LDA_TERMINOLOGY.selectPlaceholder}
+                    searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                    emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+                  />
                 )}
               </div>
 

--- a/components/lda-forms/form.tsx
+++ b/components/lda-forms/form.tsx
@@ -13,13 +13,7 @@ import {
   FormItem,
   FormLabel,
 } from "@/components/ui/form"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 
 import { LocalDevelopmentAgencyForm } from '@prisma/client'
 import { FormTemplateWithRelations, LocalDevelopmentAgencyFull } from '@/types/models'
@@ -155,23 +149,19 @@ export function FormDialog({ ldaForm, formTemplates, lda, ldas, callback }: Form
                 render={({ field }) => (
                   <FormItem className="flex-1 w-full">
                     <FormLabel>{LDA_TERMINOLOGY.fullName}</FormLabel>
-                    <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {ldas.map((lda) => (
-                          <SelectItem
-                            key={lda.id}
-                            value={lda.id.toString()}
-                          >
-                            {lda.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={ldas.map((lda) => ({
+                          value: lda.id.toString(),
+                          label: lda.name,
+                        }))}
+                        value={field.value?.toString()}
+                        onChange={field.onChange}
+                        placeholder={LDA_TERMINOLOGY.selectPlaceholder}
+                        searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                        emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+                      />
+                    </FormControl>
 
                   </FormItem>
                 )} />}
@@ -182,25 +172,21 @@ export function FormDialog({ ldaForm, formTemplates, lda, ldas, callback }: Form
               render={({ field }) => (
                 <FormItem className="flex-1 w-full">
                   <FormLabel>Form Template</FormLabel>
-                  <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {formTemplates
+                  <FormControl>
+                    <Combobox
+                      options={formTemplates
                         .filter(template => template.active === true && template.templateType !== 'REPORT')
-                        .map((template) => (
-                        <SelectItem
-                          key={template.id}
-                          value={template.id.toString()}
-                        >
-                          {template.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                        .map((template) => ({
+                          value: template.id.toString(),
+                          label: template.name,
+                        }))}
+                      value={field.value?.toString()}
+                      onChange={field.onChange}
+                      placeholder="Select a form template"
+                      searchPlaceholder="Search form templates..."
+                      emptyText="No form template found."
+                    />
+                  </FormControl>
 
                 </FormItem>
               )} />}

--- a/components/ldas/manage-lda/admin.tsx
+++ b/components/ldas/manage-lda/admin.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger, 
   SelectValue 
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { InputMultiSelect, InputMultiSelectTrigger } from "@/components/ui/multiselect"
 import { FocusArea, DevelopmentStage } from '@prisma/client'
 import { UserWithLDAsBasic } from '@/types/models'
@@ -169,23 +170,19 @@ export function AdminTab({
         render={({ field }) => (
           <FormItem>
             <FormLabel>Development stage</FormLabel>
-            <Select value={field.value?.toString()} onValueChange={field.onChange}>
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select stage" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {developmentStages.map((developmentStage) => (
-                  <SelectItem
-                    key={developmentStage.id}
-                    value={developmentStage.id.toString()}
-                  >
-                    {developmentStage.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FormControl>
+              <Combobox
+                options={developmentStages.map((developmentStage) => ({
+                  value: developmentStage.id.toString(),
+                  label: developmentStage.label,
+                }))}
+                value={field.value?.toString()}
+                onChange={field.onChange}
+                placeholder="Select stage"
+                searchPlaceholder="Search stages..."
+                emptyText="No stage found."
+              />
+            </FormControl>
           </FormItem>
         )} />
 
@@ -195,23 +192,19 @@ export function AdminTab({
         render={({ field }) => (
           <FormItem>
             <FormLabel>Assigned programme officer</FormLabel>
-            <Select value={field.value?.toString()} onValueChange={field.onChange}>
-              <FormControl>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select officer" />
-                </SelectTrigger>
-              </FormControl>
-              <SelectContent>
-                {programmeOfficers.map((programmeOfficer) => (
-                  <SelectItem
-                    key={programmeOfficer.id}
-                    value={programmeOfficer.id.toString()}
-                  >
-                    {programmeOfficer.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <FormControl>
+              <Combobox
+                options={programmeOfficers.map((programmeOfficer) => ({
+                  value: programmeOfficer.id.toString(),
+                  label: programmeOfficer.name,
+                }))}
+                value={field.value?.toString()}
+                onChange={field.onChange}
+                placeholder="Select officer"
+                searchPlaceholder="Search officers..."
+                emptyText="No officer found."
+              />
+            </FormControl>
           </FormItem>
         )} />
 

--- a/components/ldas/manage-lda/details.tsx
+++ b/components/ldas/manage-lda/details.tsx
@@ -8,13 +8,7 @@ import { Input } from "@/components/ui/input"
 import { UseFormReturn } from "react-hook-form"
 import { FormValues } from "./form-schema"
 import { Province } from "@/types/models"
-import { 
-  Select, 
-  SelectContent, 
-  SelectItem, 
-  SelectTrigger, 
-  SelectValue 
-} from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { Switch } from "@/components/ui/switch"
 import { useState, useEffect, useMemo } from "react"
 import Map from "@/components/ldas/map";
@@ -276,48 +270,41 @@ export function DetailsTab({ form, provinces }: DetailsTabProps) {
             name="physicalProvince"
             render={({ field }) => (
             <FormItem>
-              <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                <FormControl>
-                    <SelectTrigger>
-                    <SelectValue placeholder="Select province" />
-                    </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                    {provinces.map((province) => (
-                    <SelectItem
-                        key={province.code}
-                        value={province.code}
-                    >
-                        {province.name}
-                    </SelectItem>
-                    ))}
-                </SelectContent>
-                </Select>
+              <FormControl>
+                <Combobox
+                  options={provinces.map((province) => ({
+                    value: province.code,
+                    label: province.name,
+                  }))}
+                  value={field.value?.toString()}
+                  onChange={field.onChange}
+                  placeholder="Select province"
+                  searchPlaceholder="Search provinces..."
+                  emptyText="No province found."
+                />
+              </FormControl>
             </FormItem>
           )} />
-          
+
           <FormField
             control={form.control}
             name="physicalDistrict"
             render={({ field }) => (
             <FormItem>
-              <Select value={field.value?.toString()} onValueChange={field.onChange} disabled={districts.length === 0}>
-                <FormControl>
-                    <SelectTrigger>
-                  <SelectValue placeholder="Select district" />
-                    </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                    {districts.map((district) => (
-                    <SelectItem
-                        key={district.code}
-                        value={district.code}
-                    >
-                        {district.name}
-                    </SelectItem>
-                    ))}
-                </SelectContent>
-                </Select>
+              <FormControl>
+                <Combobox
+                  options={districts.map((district) => ({
+                    value: district.code,
+                    label: district.name,
+                  }))}
+                  value={field.value?.toString()}
+                  onChange={field.onChange}
+                  disabled={districts.length === 0}
+                  placeholder="Select district"
+                  searchPlaceholder="Search districts..."
+                  emptyText="No district found."
+                />
+              </FormControl>
             </FormItem>
           )} />
       </div>
@@ -386,48 +373,41 @@ export function DetailsTab({ form, provinces }: DetailsTabProps) {
             name="postalProvince"
             render={({ field }) => (
             <FormItem>
-              <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                <FormControl>
-                    <SelectTrigger>
-                    <SelectValue placeholder="Select province" />
-                    </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                    {provinces.map((province) => (
-                    <SelectItem
-                        key={province.code}
-                        value={province.code}
-                    >
-                        {province.name}
-                    </SelectItem>
-                    ))}
-                </SelectContent>
-                </Select>
+              <FormControl>
+                <Combobox
+                  options={provinces.map((province) => ({
+                    value: province.code,
+                    label: province.name,
+                  }))}
+                  value={field.value?.toString()}
+                  onChange={field.onChange}
+                  placeholder="Select province"
+                  searchPlaceholder="Search provinces..."
+                  emptyText="No province found."
+                />
+              </FormControl>
             </FormItem>
           )} />
-          
+
           <FormField
             control={form.control}
             name="postalDistrict"
             render={({ field }) => (
             <FormItem>
-              <Select value={field.value?.toString()} onValueChange={field.onChange} disabled={districts.length === 0}>
-                <FormControl>
-                    <SelectTrigger>
-                  <SelectValue placeholder="Select district" />
-                    </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                    {postalDistricts.map((district) => (
-                    <SelectItem
-                        key={district.code}
-                        value={district.code}
-                    >
-                        {district.name}
-                    </SelectItem>
-                    ))}
-                </SelectContent>
-                </Select>
+              <FormControl>
+                <Combobox
+                  options={postalDistricts.map((district) => ({
+                    value: district.code,
+                    label: district.name,
+                  }))}
+                  value={field.value?.toString()}
+                  onChange={field.onChange}
+                  disabled={districts.length === 0}
+                  placeholder="Select district"
+                  searchPlaceholder="Search districts..."
+                  emptyText="No district found."
+                />
+              </FormControl>
             </FormItem>
           )} />
       </div>

--- a/components/media/form.tsx
+++ b/components/media/form.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
@@ -210,23 +211,19 @@ export function FormDialog({ media, lda, ldas, fund, funder, mediaSourceTypes, c
                     render={({ field }) => (
                       <FormItem className="flex-1 w-full">
                         <FormLabel>{LDA_TERMINOLOGY.fullName}</FormLabel>
-                        <Select value={field.value?.toString()} onValueChange={field.onChange}>
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {ldas.map((lda) => (
-                              <SelectItem
-                                key={lda.id}
-                                value={lda.id.toString()}
-                              >
-                                {lda.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                        <FormControl>
+                          <Combobox
+                            options={ldas.map((lda) => ({
+                              value: lda.id.toString(),
+                              label: lda.name,
+                            }))}
+                            value={field.value?.toString()}
+                            onChange={field.onChange}
+                            placeholder={LDA_TERMINOLOGY.selectPlaceholder}
+                            searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                            emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+                          />
+                        </FormControl>
                       </FormItem>
                     )} />)}
                 <FormField

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+export type ComboboxOption = {
+  value: string
+  label: string
+  description?: string
+}
+
+type ComboboxProps = {
+  options: ComboboxOption[]
+  value?: string
+  onChange: (value: string) => void
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyText?: string
+  disabled?: boolean
+  className?: string
+  id?: string
+}
+
+export function Combobox({
+  options,
+  value,
+  onChange,
+  placeholder = "Select...",
+  searchPlaceholder = "Search...",
+  emptyText = "No results found.",
+  disabled = false,
+  className,
+  id,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false)
+
+  const selected = options.find((option) => option.value === value)
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            "w-full justify-between font-normal",
+            !selected && "text-muted-foreground",
+            className
+          )}
+        >
+          <span className="truncate">{selected ? selected.label : placeholder}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.value}
+                  value={option.label}
+                  onSelect={() => {
+                    onChange(option.value)
+                    setOpen(false)
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4 shrink-0",
+                      value === option.value ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  <div className="flex flex-col min-w-0">
+                    <span className="truncate">{option.label}</span>
+                    {option.description && (
+                      <span className="text-xs text-muted-foreground truncate">
+                        {option.description}
+                      </span>
+                    )}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/components/users/form.tsx
+++ b/components/users/form.tsx
@@ -30,6 +30,7 @@ import { Checkbox } from "../ui/checkbox"
 import { RadioGroup, RadioGroupItem } from "../ui/radio-group"
 import { Label } from "../ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select"
+import { Combobox } from "@/components/ui/combobox"
 import { useTranslations } from "next-intl"
 import { UserFull } from "@/types/models"
 import { usePermissions } from "@/hooks/use-permissions"
@@ -247,26 +248,19 @@ export function FormDialog({ user, callback, ldas }: FormDialogProps) {
                 render={({ field }) => (
                   <FormItem className="flex-1 w-full">
                     <FormLabel>{LDA_TERMINOLOGY.fullName}</FormLabel>
-                    <Select 
-                      value={field.value?.toString() || ''} 
-                      onValueChange={(value) => field.onChange(value)}
-                    >
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        {ldas.map((lda) => (
-                          <SelectItem
-                            key={lda.id}
-                            value={lda.id.toString()}
-                          >
-                            {lda.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <Combobox
+                        options={ldas.map((lda) => ({
+                          value: lda.id.toString(),
+                          label: lda.name,
+                        }))}
+                        value={field.value?.toString() || ''}
+                        onChange={(value) => field.onChange(value)}
+                        placeholder={LDA_TERMINOLOGY.selectPlaceholder}
+                        searchPlaceholder={`Search ${LDA_TERMINOLOGY.shortNamePlural}...`}
+                        emptyText={`No ${LDA_TERMINOLOGY.shortName} found.`}
+                      />
+                    </FormControl>
                   </FormItem>
                 )}
               />


### PR DESCRIPTION
Introduce a reusable Combobox component (Popover + Command) and use it for dropdowns backed by growing entity lists across the site: LDA, funder, fund, user, and form template pickers in forms, link dialogs, and admin panels. Dynamic form select fields switch to the searchable combobox automatically when they have more than 10 options. Short fixed enums (status, role, type, frequency) keep the plain select.