### PR TITLE
Add DB health check marker to sign-in page for uptime monitoring

### DIFF
--- a/app/[locale]/(unprotected)/sign-in/page.tsx
+++ b/app/[locale]/(unprotected)/sign-in/page.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from "react"
 import { SignInForm } from "@/components/sign-in-form"
+import { DbHealthMarker } from "@/components/db-health-marker"
 import { getTranslations } from 'next-intl/server'
 import * as Sentry from '@sentry/nextjs'
 import type { Metadata } from 'next'
@@ -22,6 +24,9 @@ export default function SignInPage() {
       <div className="w-full max-w-sm md:max-w-3xl">
         <SignInForm />
       </div>
+      <Suspense fallback={null}>
+        <DbHealthMarker />
+      </Suspense>
     </div>
   )
 }

--- a/components/db-health-marker.tsx
+++ b/components/db-health-marker.tsx
@@ -1,0 +1,31 @@
+import { unstable_noStore as noStore } from "next/cache"
+import prisma from "@/db"
+
+// UptimeRobot keyword-matches the raw HTML for "DB_UP" — keep the marker
+// strings stable, monitors are configured against them.
+const DB_CHECK_TIMEOUT_MS = 5000
+
+async function isDatabaseUp(): Promise<boolean> {
+  try {
+    await Promise.race([
+      prisma.$queryRaw`SELECT 1`,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("DB health check timed out")), DB_CHECK_TIMEOUT_MS)
+      ),
+    ])
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function DbHealthMarker() {
+  noStore()
+  const up = await isDatabaseUp()
+  return (
+    <div
+      hidden
+      dangerouslySetInnerHTML={{ __html: up ? "<!-- DB_UP -->" : "<!-- DB_DOWN -->" }}
+    />
+  )
+}


### PR DESCRIPTION
Render <!-- DB_UP --> (or <!-- DB_DOWN -->) in the sign-in page HTML based on a per-request SELECT 1 against the database, so UptimeRobot keyword monitoring can catch silent database failures such as the connection string reverting to default. The check has a 5s timeout and streams in via Suspense so a hanging database never blocks the page.