### PR TITLE
Remove stub Reporting filter, show a status badge on every LDA row

### DIFF
--- a/components/ldas/filtered.tsx
+++ b/components/ldas/filtered.tsx
@@ -6,7 +6,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { ChevronsUpDownIcon, ChevronUpIcon, ChevronDownIcon } from "lucide-react"
 import { Badge } from "../ui/badge"
 import Link from "next/link"
-import { availableReportingStatuses } from "@/app/data"
 import { LocalDevelopmentAgencyListItem, UserWithLDAsBasic } from "@/types/models"
 import { FocusArea, FundingStatus, Province, DevelopmentStage } from "@prisma/client"
 import { DynamicIcon } from "../dynamicIcon"
@@ -84,10 +83,6 @@ export const FilteredLDAs: React.FC<FilteredLDAsProps> = ({
     () => focusAreas.map(({ id, label }) => ({ id: String(id), label })),
     [focusAreas]
   )
-  const reportingOptions = useMemo<FilterOption[]>(
-    () => availableReportingStatuses.map(({ value, label }) => ({ id: String(value), label })),
-    []
-  )
   const poOptions = useMemo<FilterOption[]>(
     () => programmeOfficers.map(({ id, name }) => ({ id: String(id), label: name })),
     [programmeOfficers]
@@ -98,9 +93,8 @@ export const FilteredLDAs: React.FC<FilteredLDAsProps> = ({
     { type: 'stage', label: 'Stage', options: stageOptions },
     { type: 'location', label: 'Province', options: locationOptions },
     { type: 'focus', label: 'Focus area', options: focusOptions },
-    { type: 'reporting', label: 'Reporting', options: reportingOptions },
     { type: 'po', label: 'PO', options: poOptions },
-  ]), [statusOptions, stageOptions, locationOptions, focusOptions, reportingOptions, poOptions])
+  ]), [statusOptions, stageOptions, locationOptions, focusOptions, poOptions])
 
   const handleSort = useCallback((column: SortableColumn) => {
     setSortColumn(prev => {
@@ -146,7 +140,6 @@ export const FilteredLDAs: React.FC<FilteredLDAsProps> = ({
     const locSel = sel('location')
     const stageSel = sel('stage')
     const statusSel = sel('status')
-    const reportingSel = sel('reporting') // unused for now
     const poSel = sel('po')
 
     let result = ldasIndexed.filter(lda => {
@@ -157,9 +150,8 @@ export const FilteredLDAs: React.FC<FilteredLDAsProps> = ({
       const stageMatch = !stageSel.length || stageSel.includes(String(lda.developmentStageId))
       const statusMatch = !statusSel.length || statusSel.includes(String(lda.fundingStatusId))
       const poMatch = !poSel.length || (lda.programmeOfficerId && poSel.includes(String(lda.programmeOfficerId)))
-      const reportingMatch = !reportingSel.length // TODO when model supports it
 
-      return focusMatch && locMatch && stageMatch && statusMatch && poMatch && reportingMatch
+      return focusMatch && locMatch && stageMatch && statusMatch && poMatch
     })
 
     if (sortColumn && sortDirection) {
@@ -221,7 +213,9 @@ export const FilteredLDAs: React.FC<FilteredLDAsProps> = ({
           <Link href={getLDAlink(lda.id)} prefetch={false}>{lda.name}</Link>
         </TableCell>
         <TableCell className="p-2">
-          {lda.fundingStatus && <Badge variant="outline">{lda.fundingStatus.label}</Badge>}
+          {lda.fundingStatus
+            ? <Badge variant="outline">{lda.fundingStatus.label}</Badge>
+            : <Badge variant="outline" className="border-dashed text-gray-400">No status</Badge>}
         </TableCell>
         <TableCell className="p-2">
           {lda.developmentStage && <Badge variant="outline">{lda.developmentStage.label}</Badge>}


### PR DESCRIPTION
The Reporting filter never filtered anything (its match was a TODO that always passed). Rows without a funding status now show a muted 'No status' badge instead of an empty cell.