### PR TITLE
Disable zoom-to-location when the map is already at the pin

### DIFF
--- a/components/ldas/map/lda-map.tsx
+++ b/components/ldas/map/lda-map.tsx
@@ -4,8 +4,8 @@ import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 import "leaflet.fullscreen/Control.FullScreen.css";
 import "leaflet.fullscreen/Control.FullScreen.js";
-import { useEffect, useRef } from "react";
-import { MapContainer, TileLayer, Marker, Popup, useMap, ZoomControl } from "react-leaflet";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { MapContainer, TileLayer, Marker, Popup, useMap, useMapEvents, ZoomControl } from "react-leaflet";
 import Link from "next/link";
 import { LocalDevelopmentAgencyListItem } from "@/types/models";
 import { LDA_TERMINOLOGY, OrganisationStatus } from "@/constants/lda";
@@ -54,13 +54,30 @@ function FullscreenControl() {
 }
 
 // Popup action that flies the map to the marker at street level
+const PIN_ZOOM = 15;
+
 function ZoomToPin({ position }: { position: [number, number] }) {
   const map = useMap();
+  // Disabled when zooming would be a no-op: already at street zoom with the
+  // pin near the centre of the view
+  const [atLocation, setAtLocation] = useState(false);
+
+  const update = useCallback(() => {
+    const zoomedIn = map.getZoom() >= PIN_ZOOM;
+    const centered = map.getCenter().distanceTo(L.latLng(position[0], position[1])) < 250;
+    setAtLocation(zoomedIn && centered);
+  }, [map, position]);
+
+  useMapEvents({ zoomend: update, moveend: update });
+  useEffect(() => { update() }, [update]);
+
   return (
     <button
       type="button"
-      onClick={() => map.flyTo(position, 15)}
-      className="text-blue-600 hover:underline font-medium"
+      onClick={() => map.flyTo(position, PIN_ZOOM)}
+      disabled={atLocation}
+      title={atLocation ? "Already at this location" : undefined}
+      className={`font-medium ${atLocation ? "text-slate-400 cursor-default" : "text-blue-600 hover:underline"}`}
     >
       Zoom to location
     </button>


### PR DESCRIPTION
Greys out the popup link (with an explanatory tooltip) once the map is at street zoom with the pin near the view centre, tracking zoomend and moveend so it re-enables when the user pans or zooms away.