### PR TITLE
Fix Activities section falsely showing incomplete in narrative report

### DIFF
--- a/components/form-templates/custom-layouts/narrative-repeatable.tsx
+++ b/components/form-templates/custom-layouts/narrative-repeatable.tsx
@@ -10,6 +10,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion"
 import { FormField } from "../form-field"
+import { isFieldComplete } from "@/lib/form-validation/field-completeness"
 import { useState } from "react"
 import { format } from "date-fns"
 
@@ -61,17 +62,11 @@ export function NarrativeRepeatableLayout({ inputField, isEditing, onValueChange
     return <span className="font-semibold">{`${defaultLabel} ${groupIndex}`}</span>
   }
 
-  // Check if a group is complete (all required fields have values)
+  // Check if a group is complete (all required fields have values).
+  // isFieldComplete recurses into nested group fields (e.g. the attendance
+  // count groups), which have no scalar value of their own.
   const isGroupComplete = (groupItems: Field[]): boolean => {
-    return groupItems.every(field => {
-      // Skip non-required fields
-      if (!field.required) return true
-      // Skip fields that are hidden via show_if
-      if (field.show === false) return true
-      // Check if field has a value
-      const value = field.value?.trim()
-      return value !== undefined && value !== ''
-    })
+    return groupItems.every(isFieldComplete)
   }
 
   const handleRemove = (groupIndex: number) => {

--- a/components/form-templates/form-accordion-item.tsx
+++ b/components/form-templates/form-accordion-item.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState, useEffect, useCallback, useRef } from "react"
 import { AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { CircleSmall, Lock } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { isScalarValueComplete, computeGroupValidity } from "@/lib/form-validation/field-completeness"
 import { FormField } from "@/components/form-templates/form-field"
 import { Section, Field, FormData, DependsOnRule } from "@/types/forms"
 import { useFormValuesStore } from "@/components/form-templates/form-values-context"
@@ -71,17 +72,7 @@ export default function FormAccordionItem({
 
   const isSectionVisible = isRoleVisible && isShowIfVisible;
 
-  const isValueValid = (value: string, field: Field) => {
-    if (field.type === "fileUpload") {
-      if (!value || value.trim() === "") return false;
-      try {
-        return JSON.parse(value).length > 0;
-      } catch {
-        return false;
-      }
-    }
-    return value.trim() !== "";
-  }
+  const isValueValid = (value: string, field: Field) => isScalarValueComplete(value, field.type)
 
   const createFieldFromTemplate = useCallback((field: Field, index: number) => {
     const fields = [...(field?.template || [])];
@@ -275,13 +266,10 @@ export default function FormAccordionItem({
             // Recursively process nested fields if they exist
             if (subfield.fields && subfield.fields.length > 0) {
               const nestedFields = processFieldsRecursively(subfield.fields, subfieldName, false);
-              const requiredNestedFields = nestedFields.filter(nf => nf.required);
-              const allNestedValid = requiredNestedFields.length > 0 ? 
-                requiredNestedFields.every(nf => nf.isValid) : true;
-              subFieldObj = { 
-                ...subFieldObj, 
-                fields: nestedFields,
-                isValid: subfield.required ? allNestedValid : true
+              subFieldObj = { ...subFieldObj, fields: nestedFields };
+              subFieldObj = {
+                ...subFieldObj,
+                isValid: subfield.required ? computeGroupValidity(subFieldObj) : true
               };
             }
             
@@ -599,11 +587,24 @@ export default function FormAccordionItem({
               const subFields = newFields.flat().map((subfield) => {
                 // Respect show: false from template, otherwise check show_if
                 const showField = subfield.show === false ? false : (subfield.show_if ? false : true);
-                const subFieldObj = {
+                let subFieldObj: Field = {
                   ...subfield,
                   show: showField,
                   isValid: subfield.required ? false : true
                 };
+                // Nested group children (e.g. attendance counts): initialize each
+                // child, then derive the group's validity from them — otherwise a
+                // required group starts isValid:false and can never flip true
+                if (subfield.fields && subfield.fields.length > 0) {
+                  const nestedFields = subfield.fields.map((nested: Field) => ({
+                    ...nested,
+                    show: nested.show === false ? false : (nested.show_if ? false : true),
+                    // ?? preserves isValid:true set for hydrated default values
+                    isValid: nested.isValid ?? (nested.required ? false : true),
+                  }));
+                  subFieldObj = { ...subFieldObj, fields: nestedFields };
+                  subFieldObj.isValid = subfield.required ? computeGroupValidity(subFieldObj) : true;
+                }
                 return subFieldObj;
               });
 
@@ -664,7 +665,7 @@ export default function FormAccordionItem({
               const matchingRule = subfield.depends_on.rules?.find((rule: DependsOnRule) => rule.when === value);
               const newOptions = matchingRule?.options || subfield.depends_on.default_options || subfield.options;
               subfield = { ...subfield, options: newOptions, value: "", isValid: subfield.required ? false : true };
-              
+
               // Save the cleared value to API after a delay to not interfere with the original field save
               const dependentSubfieldName = subfield.name;
               setTimeout(() => {
@@ -672,6 +673,35 @@ export default function FormAccordionItem({
                   debouncedSaveRef.current(dependentSubfieldName, "");
                 }
               }, 600);
+            }
+
+            // Nested group children (e.g. attendance counts inside a repeatable
+            // entry): the changed field lives one level deeper than this map
+            // reaches, so update it here and recompute the group's validity
+            if (subfield.fields && subfield.fields.length > 0) {
+              let nestedChanged = false;
+              const nestedFields = subfield.fields.map((nested: Field) => {
+                if (nested.name === field.name) {
+                  nestedChanged = true;
+                  return {
+                    ...nested,
+                    value,
+                    isValid: nested.required ? isScalarValueComplete(value, nested.type) : true,
+                  };
+                }
+                if (nested.show_if !== undefined && nested.show_if.field === field.name) {
+                  nestedChanged = true;
+                  return { ...nested, show: value === nested.show_if.value };
+                }
+                return nested;
+              });
+              if (nestedChanged) {
+                subfield = { ...subfield, fields: nestedFields };
+                subfield = {
+                  ...subfield,
+                  isValid: subfield.required ? computeGroupValidity(subfield) : true,
+                };
+              }
             }
             return subfield;
           }) as Field[];

--- a/lib/form-validation/field-completeness.ts
+++ b/lib/form-validation/field-completeness.ts
@@ -1,0 +1,46 @@
+import type { Field } from "@/types/forms"
+
+// Shared completeness rules for form-template fields. Three consumers must
+// agree — load-time hydration and live onChange updates in
+// form-accordion-item.tsx, and the per-entry card badge in
+// narrative-repeatable.tsx — and previously drifted: `group` fields hold no
+// scalar value (their data lives in nested children), so any check reading
+// `field.value` reports a filled group as incomplete forever.
+
+/** Non-empty check for a scalar field value; fileUpload stores a JSON array. */
+export function isScalarValueComplete(value: string, type?: string): boolean {
+  if (type === "fileUpload") {
+    if (!value || value.trim() === "") return false
+    try {
+      return JSON.parse(value).length > 0
+    } catch {
+      return false
+    }
+  }
+  return value.trim() !== ""
+}
+
+/**
+ * Value-based completeness for an already-hydrated field tree (e.g. the
+ * per-entry fields of a repeatable). Hidden, info, and optional fields pass;
+ * groups recurse into their children; scalars need a non-empty value.
+ */
+export function isFieldComplete(field: Field): boolean {
+  if (field.show === false) return true
+  if (field.type === "info") return true
+  if (!field.required) return true
+  if (field.fields && field.fields.length > 0) {
+    return field.fields.every(isFieldComplete)
+  }
+  return isScalarValueComplete(field.value ?? "", field.type)
+}
+
+/**
+ * isValid-based completeness of a group, derived from its children's already
+ * computed `isValid` flags: every visible required child must be valid.
+ */
+export function computeGroupValidity(group: Field): boolean {
+  return (group.fields ?? []).every((child) =>
+    child.show !== false && child.required ? Boolean(child.isValid) : true
+  )
+}

--- a/scripts/tests/field-completeness.test.ts
+++ b/scripts/tests/field-completeness.test.ts
@@ -1,0 +1,75 @@
+// Run with: npx tsx scripts/tests/field-completeness.test.ts
+import assert from "node:assert/strict"
+import {
+  isScalarValueComplete,
+  isFieldComplete,
+  computeGroupValidity,
+} from "../../lib/form-validation/field-completeness"
+import type { Field } from "../../types/forms"
+
+const field = (overrides: Partial<Field>): Field =>
+  ({ name: "f", type: "text", label: "F", ...overrides } as Field)
+
+// --- isScalarValueComplete ---
+assert.equal(isScalarValueComplete("hello"), true)
+assert.equal(isScalarValueComplete("  "), false)
+assert.equal(isScalarValueComplete(""), false)
+assert.equal(isScalarValueComplete('["file.pdf"]', "fileUpload"), true)
+assert.equal(isScalarValueComplete("[]", "fileUpload"), false)
+assert.equal(isScalarValueComplete("", "fileUpload"), false)
+assert.equal(isScalarValueComplete("not-json", "fileUpload"), false)
+
+// --- isFieldComplete: scalars ---
+assert.equal(isFieldComplete(field({ required: true, value: "x" })), true)
+assert.equal(isFieldComplete(field({ required: true, value: "" })), false)
+assert.equal(isFieldComplete(field({ required: true })), false, "required without value")
+assert.equal(isFieldComplete(field({ required: false })), true, "optional passes")
+assert.equal(isFieldComplete(field({ required: true, show: false })), true, "hidden passes")
+assert.equal(isFieldComplete(field({ required: true, type: "info" })), true, "info passes")
+
+// --- isFieldComplete: groups (no scalar value of their own) ---
+const attendanceGroup = (childValues: Array<string | undefined>): Field =>
+  field({
+    name: "overall_attendance",
+    type: "group",
+    required: true,
+    fields: childValues.map((v, i) =>
+      field({ name: `n${i}`, type: "number", required: true, value: v })
+    ),
+  })
+assert.equal(isFieldComplete(attendanceGroup(["1", "2", "3"])), true, "filled group complete")
+assert.equal(isFieldComplete(attendanceGroup(["1", "", "3"])), false, "empty child incomplete")
+assert.equal(isFieldComplete(attendanceGroup(["1", undefined, "3"])), false)
+assert.equal(
+  isFieldComplete(field({ type: "group", required: false, fields: [field({ required: true, value: "" })] })),
+  true,
+  "optional group passes"
+)
+assert.equal(
+  isFieldComplete(field({ type: "group", required: true, show: false, fields: [field({ required: true, value: "" })] })),
+  true,
+  "hidden group passes"
+)
+// group whose empty child is hidden is complete
+assert.equal(
+  isFieldComplete(
+    field({
+      type: "group",
+      required: true,
+      fields: [field({ required: true, value: "1" }), field({ required: true, value: "", show: false })],
+    })
+  ),
+  true
+)
+
+// --- computeGroupValidity (isValid-based) ---
+const validityGroup = (children: Array<Partial<Field>>): Field =>
+  field({ type: "group", required: true, fields: children.map((c, i) => field({ name: `c${i}`, ...c })) })
+assert.equal(computeGroupValidity(validityGroup([{ required: true, isValid: true }])), true)
+assert.equal(computeGroupValidity(validityGroup([{ required: true, isValid: false }])), false)
+assert.equal(computeGroupValidity(validityGroup([{ required: true, isValid: undefined }])), false, "undefined isValid counts invalid")
+assert.equal(computeGroupValidity(validityGroup([{ required: false, isValid: false }])), true, "optional child ignored")
+assert.equal(computeGroupValidity(validityGroup([{ required: true, isValid: false, show: false }])), true, "hidden child ignored")
+assert.equal(computeGroupValidity(field({ type: "group" })), true, "no children = valid")
+
+console.log("field-completeness: all assertions passed")


### PR DESCRIPTION
The Activities repeatable nests required group fields (overall attendance, demographics) whose data lives in nested number children, but completeness checks only handled one nesting level:

- The per-activity card badge checked field.value on group fields, which have no scalar value — so activities with attendance groups showed Incomplete forever, even after reload.
- onChange only walked the repeatable's flat fields, so typing into the nested attendance numbers never updated state or the group's isValid; the section header stayed short until a reload. Newly added entries also seeded groups isValid:false without initializing children.

Shared rules now live in lib/form-validation/field-completeness (isScalarValueComplete / isFieldComplete / computeGroupValidity), used by the card badge, load-time hydration, the onChange nested-child branch, and the add-entry seed loop, so the paths can't drift. Covered by scripts/tests/field-completeness.test.ts (npx tsx).